### PR TITLE
default to job id for reservation value

### DIFF
--- a/redis_reservation/__init__.py
+++ b/redis_reservation/__init__.py
@@ -16,7 +16,10 @@ class ReserveResource:
     
   def __init__(self, redis, key, by, lock_ttl=30*60, heartbeat_interval=10*60):
     self.key = 'reservation-{}'.format(key)
-    self.val = '{}-{}-{}'.format(socket.gethostname(), by, os.getpid())
+    id = os.getenv("JOB_ID")
+    if id is None:
+      id = os.getpid()
+    self.val = '{}-{}-{}'.format(socket.gethostname(), by, id)
     self.lock_ttl = lock_ttl
     self.heartbeat_interval = heartbeat_interval
     self.redis = redis

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 from setuptools import setup, find_packages
 
-__version__ = '0.1.1'
+__version__ = '0.2.1'
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
to match https://github.com/Clever/node-redis-reservation/blob/45e5090d714d167dc5f6b406ad7b626521499569/lib/index.coffee#L27

rollout would probably look something like:
1. scale down worker to 0
2. merge and deploy with a bumped `requirements.txt` file
3. scale worker back up