### PR TITLE
python3 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,19 +3,19 @@ jobs:
   build:
     working_directory: ~/Clever/python-redis-reservation
     docker:
-    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-    - image: redis
+    - image: cimg/python:3.9.12
+    - image: cimg/redis:6.2.6
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
+    - run: pip3 install --force-reinstall pip==22.0.4
     - run:
         command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
         name: Clone ci-scripts
     - checkout
-    - setup_remote_docker
     - run:
         command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
         name: Set up CircleCI artifacts directories
-    - run: sudo python setup.py develop
-    - run: sudo python setup.py test
+    - run: python3 setup.py develop
+    - run: python3 setup.py test

--- a/redis_reservation/__init__.py
+++ b/redis_reservation/__init__.py
@@ -1,3 +1,4 @@
+from builtins import object
 from contextlib import contextmanager
 from threading import Timer
 import threading
@@ -14,7 +15,7 @@ class ReserveException(Exception):
   pass
 
 
-class ReserveResource:
+class ReserveResource(object):
     
   def __init__(self, redis, key, by, kvlogger=logger.Logger("redis-reservation"), lock_ttl=30*60, heartbeat_interval=10*60):
     self.key = 'reservation-{}'.format(key)
@@ -47,7 +48,7 @@ class ReserveResource:
           self.logger.info("reserved", dict(key=self.key))
           yield True
         else:
-          self.logger.info("already-reserved", dict(key=self.key, by=self.redis.get(self.key)))
+          self.logger.info("already-reserved", dict(key=self.key, by=self.redis.get(self.key).decode('utf-8')))
           yield False
     except RedisError as err:
       self.logger.error("redis-error", dict(err=repr(err)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-redis==2.8.0
-kayvee>=2.0.2
+redis==4.2.2
+kayvee>=3.0.0
+future==0.18.2

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python
 
+from builtins import str
 import os
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+try:  # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError:  # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 import pkg_resources
 
-__version__ = '0.3.1'
+__version__ = '1.0.0'
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -19,9 +23,8 @@ except:
     README = ''
     CHANGES = ''
 
-pr_kwargs = {}
-if pkg_resources.get_distribution("pip").version >= '6.0':
-  pr_kwargs = {"session": False}
+
+pr_kwargs = {"session": False}
 
 install_reqs = parse_requirements(
     os.path.join(
@@ -38,7 +41,7 @@ setup(name='redis_reservation',
       url='https://github.com/Clever/python-redis-reservation',
       license='Apache License 2.0',
       packages=find_packages(exclude=['*.tests']),
-      install_requires=[str(ir.req) for ir in install_reqs],
+      install_requires=[str(ir.requirement) for ir in install_reqs],
       setup_requires=['nose>=1.0'],
       test_suite='redis_reservation.tests',
       entry_points={


### PR DESCRIPTION
While we are planning on attempting to switch our sis workers to node, we would like an updated python version of the workers to fall back on if needed https://clever.atlassian.net/browse/DID-566. This is the first step of switching workers to Python 3.0. This library is used in baseworker-python and therefore all of our Python sis workers.

Steps to actually update the code were straight forward. Laid out here https://python-future.org/futurize_cheatsheet.html?highlight=futurize.  Had to switch all the results fo value fetches to decoded binary string with the new redis libarary